### PR TITLE
Specify a particular Vulkan version as target environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 build-from-source = ["shaderc/build-from-source"]
 
 [dependencies]
-shaderc = "0.6.2"
+shaderc = "0.7.0"
 syn = "1.0.38"
 quote = "1.0.7"
 


### PR DESCRIPTION
The current solution uses Vulkan 1.0 as the target environment, which means that shaders using SPIR-V higher than 1.0 cannot be compiled.
This PR adds 3 new keywords that can be passed as parameters to `inline/include_spirv!` macro, making Vulkan version customizable - `vulkan1_0` (SPIR-V 1.0, default), `vulkan1_1` (SPIR-V 1.3) and `vulkan1_2` (SPIR-V 1.5).