### PR TITLE
Allow wider range of `shaderc` dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hlsl = ["shaderc"]
 glsl = ["shaderc"]
 
 [dependencies]
-shaderc = { version = "0.7.2", optional = true }
+shaderc = { version = ">=0.7.2, <=0.8", optional = true }
 naga = { version = "0.5.0", features = ["wgsl-in", "spv-out"], optional = true }
 syn = "1.0.38"
 quote = "1.0.7"

--- a/src/backends/shaderc.rs
+++ b/src/backends/shaderc.rs
@@ -98,7 +98,7 @@ pub(crate) fn compile(
     }
 
     let dep_paths = RefCell::new(Vec::new());
-    let mut compiler = shaderc::Compiler::new().unwrap();
+    let compiler = shaderc::Compiler::new().unwrap();
     let path = if let Some(path) = path {
         dep_paths.borrow_mut().push(path.to_owned());
         path


### PR DESCRIPTION
It appears the newer versions of shaderc don't conflict with the usage here. This allows other projects to use the newer `0.8` version for things and still include `inline-spirv`.